### PR TITLE
Inspection for Sameness

### DIFF
--- a/src/main/kotlin/org/ice1000/kala/SamenessInspection.kt
+++ b/src/main/kotlin/org/ice1000/kala/SamenessInspection.kt
@@ -1,0 +1,43 @@
+package org.ice1000.kala
+
+import com.intellij.codeInspection.CommonQuickFixBundle
+import com.intellij.codeInspection.LocalQuickFix
+import com.intellij.codeInspection.ProblemDescriptor
+import com.intellij.codeInspection.ProblemHighlightType
+import com.intellij.codeInspection.ProblemsHolder
+import com.intellij.openapi.project.Project
+import com.intellij.psi.JavaPsiFacade
+import com.intellij.psi.PsiElementVisitor
+
+// TODO: This also works for non-kala method
+class SamenessInspection : KalaInspection() {
+  companion object {
+    private const val METHOD_NAME: String = "sameElements"
+  }
+  
+  private object FIX : LocalQuickFix {
+    override fun getFamilyName(): String = CommonQuickFixBundle.message("fix.replace.with.x", "true")
+    
+    override fun applyFix(project: Project, descriptor: ProblemDescriptor) {
+      descriptor.psiElement.replace(JavaPsiFacade.getElementFactory(project)
+        .createExpressionFromText("true", descriptor.endElement))
+    }
+  }
+  
+  override fun getDisplayName(): String = KalaBundle.message("kala.sameness")
+  
+  override fun buildVisitor(holder: ProblemsHolder, isOnTheFly: Boolean): PsiElementVisitor = methodCallVisitor {
+    val args = it.argumentList.expressions
+    val methodExpr = it.methodExpression
+    val self = methodExpr.qualifierExpression?.reference?.resolve() ?: return@methodCallVisitor
+    if (args.isEmpty()) return@methodCallVisitor
+    if (methodExpr.referenceName != METHOD_NAME) return@methodCallVisitor
+    val arg = args.first().reference?.resolve() ?: return@methodCallVisitor
+    
+    if (self == arg) {
+      holder.registerProblem(holder.manager.createProblemDescriptor(
+        it, displayName, FIX, ProblemHighlightType.WARNING, isOnTheFly
+      ))
+    }
+  }
+}

--- a/src/main/kotlin/org/ice1000/kala/SamenessInspection.kt
+++ b/src/main/kotlin/org/ice1000/kala/SamenessInspection.kt
@@ -1,6 +1,5 @@
 package org.ice1000.kala
 
-import com.intellij.codeInspection.CommonQuickFixBundle
 import com.intellij.codeInspection.LocalQuickFix
 import com.intellij.codeInspection.ProblemDescriptor
 import com.intellij.codeInspection.ProblemHighlightType
@@ -8,33 +7,38 @@ import com.intellij.codeInspection.ProblemsHolder
 import com.intellij.openapi.project.Project
 import com.intellij.psi.JavaPsiFacade
 import com.intellij.psi.PsiElementVisitor
+import com.intellij.psi.util.InheritanceUtil
+import com.siyeh.InspectionGadgetsBundle
 
-// TODO: This also works for non-kala method
 class SamenessInspection : KalaInspection() {
   companion object {
     private const val METHOD_NAME: String = "sameElements"
   }
   
   private object FIX : LocalQuickFix {
-    override fun getFamilyName(): String = CommonQuickFixBundle.message("fix.replace.with.x", "true")
+    override fun getFamilyName(): String = InspectionGadgetsBundle.message("constant.conditional.expression.simplify.quickfix")
     
     override fun applyFix(project: Project, descriptor: ProblemDescriptor) {
       descriptor.psiElement.replace(JavaPsiFacade.getElementFactory(project)
         .createExpressionFromText("true", descriptor.endElement))
     }
   }
-  
-  override fun getDisplayName(): String = KalaBundle.message("kala.sameness")
+
+  override fun getDisplayName(): String = InspectionGadgetsBundle.message("boolean.expression.can.be.simplified.problem.descriptor", "true")
   
   override fun buildVisitor(holder: ProblemsHolder, isOnTheFly: Boolean): PsiElementVisitor = methodCallVisitor {
     val args = it.argumentList.expressions
     val methodExpr = it.methodExpression
-    val self = methodExpr.qualifierExpression?.reference?.resolve() ?: return@methodCallVisitor
+    val selfExpr = methodExpr.qualifierExpression ?: return@methodCallVisitor
     if (args.isEmpty()) return@methodCallVisitor
     if (methodExpr.referenceName != METHOD_NAME) return@methodCallVisitor
-    val arg = args.first().reference?.resolve() ?: return@methodCallVisitor
-    
-    if (self == arg) {
+    val argExpr = args.first() ?: return@methodCallVisitor
+
+    val self = selfExpr.reference?.resolve() ?: return@methodCallVisitor
+    val arg = argExpr.reference?.resolve() ?: return@methodCallVisitor
+
+    if (InheritanceUtil.isInheritor(selfExpr.type, "$PKG.base.Traversable")
+      && self == arg) {
       holder.registerProblem(holder.manager.createProblemDescriptor(
         it, displayName, FIX, ProblemHighlightType.WARNING, isOnTheFly
       ))

--- a/src/main/kotlin/org/ice1000/kala/utils.kt
+++ b/src/main/kotlin/org/ice1000/kala/utils.kt
@@ -20,7 +20,8 @@ class KalaInspectionProvider : InspectionToolProvider {
     ViewSizeInspection::class.java,
     SizeCompareInspection::class.java,
     MapPutUnetaInspection::class.java,
-    ViewToMapInspection::class.java
+    ViewToMapInspection::class.java,
+    SamenessInspection::class.java
   )
 }
 

--- a/src/main/resources/inspectionDescriptions/Sameness.html
+++ b/src/main/resources/inspectionDescriptions/Sameness.html
@@ -1,0 +1,5 @@
+<html>
+<body>
+This is a example inspection, TODO: fixme.
+</body>
+</html>

--- a/src/main/resources/inspectionDescriptions/Sameness.html
+++ b/src/main/resources/inspectionDescriptions/Sameness.html
@@ -1,5 +1,5 @@
 <html>
 <body>
-This is a example inspection, TODO: fixme.
+This inspection warns about comparing an <code>Traversable</code> with itself by <code>sameElements</code>.
 </body>
 </html>

--- a/src/main/resources/kala/kala-bundle.properties
+++ b/src/main/resources/kala/kala-bundle.properties
@@ -8,3 +8,4 @@ kala.view-size.name=.size() is dangerous, may compute the entire view
 kala.size-compare.name=Can be replaced with optimized ad-hoc size comparison
 kala.map-put-uneta.name=Map.put supports tuple argument
 kala.view-to-map.name=Convert to type-safe factory call
+kala.sameness=Always true

--- a/src/main/resources/kala/kala-bundle.properties
+++ b/src/main/resources/kala/kala-bundle.properties
@@ -8,4 +8,3 @@ kala.view-size.name=.size() is dangerous, may compute the entire view
 kala.size-compare.name=Can be replaced with optimized ad-hoc size comparison
 kala.map-put-uneta.name=Map.put supports tuple argument
 kala.view-to-map.name=Convert to type-safe factory call
-kala.sameness=Always true


### PR DESCRIPTION
`kala-inspections` will warn `xxx.sameElements(xxx)` now. This can save our (my) time.