### PR TITLE
More Dblity

### DIFF
--- a/src/main/kotlin/org/ice1000/kala/DblityInspection.kt
+++ b/src/main/kotlin/org/ice1000/kala/DblityInspection.kt
@@ -17,6 +17,15 @@ class DblityInspection : AbstractBaseJavaLocalInspectionTool() {
     fun toAnnotationName(): String {
       return "@$this"
     }
+
+    /**
+     * Check if [other] is assignable to [this], or in other words, [this] is assignable from [other]
+     * @return negative, if not assignable, positive if assignable with cast
+     */
+    fun isAssignable(other: Kind): Int {
+      val other = if (other == Inherit) Bound else other
+      return other.compareTo(this)
+    }
   }
 
   // Make it nullable even we don't really return null,
@@ -89,8 +98,8 @@ class DblityInspection : AbstractBaseJavaLocalInspectionTool() {
       || actualKind == null
     ) return
 
-    val cmp = expectedKind.compareTo(actualKind)
-    if (cmp > 0) {
+    val cmp = expectedKind.isAssignable(actualKind)
+    if (cmp < 0) {
       // not assignable
       holder.registerProblem(
         actual,
@@ -101,7 +110,7 @@ class DblityInspection : AbstractBaseJavaLocalInspectionTool() {
         ),
         ProblemHighlightType.WARNING
       )
-    } else if (cmp < 0) {
+    } else if (cmp > 0) {
       // assignable with implicit cast
       // TODO: I want to make some highlight, but how?
       // sorry holder

--- a/src/main/kotlin/org/ice1000/kala/DblityInspection.kt
+++ b/src/main/kotlin/org/ice1000/kala/DblityInspection.kt
@@ -85,8 +85,8 @@ class DblityInspection : AbstractBaseJavaLocalInspectionTool() {
 
     if (expectedKind == null
       || expectedKind == Kind.Inherit
+      // don't skip if `actualKind` is `Inherit`, we treat rhs `Inherit` as Bound, but still skip if no kind
       || actualKind == null
-      || actualKind == Kind.Inherit
     ) return
 
     val cmp = expectedKind.compareTo(actualKind)

--- a/src/test/resources/dblity/.gitignore
+++ b/src/test/resources/dblity/.gitignore
@@ -1,0 +1,30 @@
+### IntelliJ IDEA ###
+out/
+!**/src/main/**/out/
+!**/src/test/**/out/
+.idea/
+
+### Eclipse ###
+.apt_generated
+.classpath
+.factorypath
+.project
+.settings
+.springBeans
+.sts4-cache
+bin/
+!**/src/main/**/bin/
+!**/src/test/**/bin/
+
+### NetBeans ###
+/nbproject/private/
+/nbbuild/
+/dist/
+/nbdist/
+/.nb-gradle/
+
+### VS Code ###
+.vscode/
+
+### Mac OS ###
+.DS_Store

--- a/src/test/resources/dblity/src/Bound.java
+++ b/src/test/resources/dblity/src/Bound.java
@@ -1,0 +1,6 @@
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Target;
+
+@Target({ElementType.PARAMETER, ElementType.TYPE_USE})
+public @interface Bound {
+}

--- a/src/test/resources/dblity/src/Closed.java
+++ b/src/test/resources/dblity/src/Closed.java
@@ -1,0 +1,6 @@
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Target;
+
+@Target({ElementType.PARAMETER, ElementType.TYPE_USE})
+public @interface Closed {
+}

--- a/src/test/resources/dblity/src/Main.java
+++ b/src/test/resources/dblity/src/Main.java
@@ -1,0 +1,45 @@
+//TIP To <b>Run</b> code, press <shortcut actionId="Run"/> or
+// click the <icon src="AllIcons.Actions.Execute"/> icon in the gutter.
+public class Main {
+    public interface Term {}
+    public record SubTerm(Term inheritSubTerm, @Closed Term closedSubTerm, int integer) implements Term {
+        public void doSomething() {
+            // warning
+            acceptClosedTerm(inheritSubTerm);
+            // ok
+            acceptBoundTerm(inheritSubTerm);
+            // ok
+            acceptClosedTerm(closedSubTerm);
+        }
+    }
+
+    public static void acceptClosedTerm(@Closed Term term) {}
+
+    public static void acceptBoundTerm(@Bound Term term) {}
+
+    public void testSubterm(@Bound SubTerm sub) {
+        // sub.inheritSubTerm inherits the db-closeness from the receiver,
+        // thus it is Bound
+        acceptClosedTerm(sub.inheritSubTerm());
+
+        // ok
+        acceptClosedTerm(sub.closedSubTerm());
+
+        // ok, closed term can be used as bound term
+        acceptBoundTerm(sub.closedSubTerm());
+
+        // this work cause `i` is inherit, NOT cause `i` is inferred to `Bound`
+        var i = sub.inheritSubTerm();
+        acceptClosedTerm(i);
+        // ok, `Inherit` is treated as `Bound` at rhs
+        acceptBoundTerm(i);
+
+        @Closed Term j;
+        // ok, even `i` is `Inherit`, this is the only way to cast an `Inherit` to `Closed`
+        j = i;
+
+        // the return type of any method will inherit the db-closeness from the receiver, even types don't match
+        @Closed int ii;
+        ii = sub.integer();
+    }
+}


### PR DESCRIPTION
This PR:
Treat rhs `Inherit` as `Bound` when inspecting method/constructor calls, but not when inspecting variable assignments, this is the only way you can cast an `Inherit` term to a `Closed` term.

Some bug and idea:
* visitAssignment does NOT visit variable declaration with initializer.
* we need to visit the return statement and check against the return type of the method or lambda.
* deal with vararg
* make this inspection more configurable, such that we can make a white list and reduce inspections on uninterested types.